### PR TITLE
Error handling

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -224,6 +224,10 @@ export default class Menu extends Component {
       }
     };
 
+    this.xhr.onerror = () => {
+      this.props.handleErrorFailedRequestOpen('Request Failed');
+    };
+
     this.xhr.open('GET', `${this.props.autoCompleteAddress}search/${address}`, true);
     this.xhr.send();
   }
@@ -384,6 +388,7 @@ Menu.propTypes = {
   setRangePolygonAutocompleteDestination: PropTypes.func.isRequired,
   handleIndicateStartSnackbarOpen: PropTypes.func.isRequired,
   handleRemainingRangeSnackbarOpen: PropTypes.func.isRequired,
+  handleErrorFailedRequestOpen: PropTypes.func.isRequired,
 };
 
 Menu.defaultProps = {


### PR DESCRIPTION
Adding error handling for xhr request in Menu.js and fetch request in
GreenNav.js. Also, when there is server response with Error: could not find
path that has been handle dynamically within GreenNav.js

Changing response.json() to response.text() because whenever there is "Error: could not find path" server response, this throws an error and which is matched by .catch() . Using try and catch instead of using if else helps in handling response errors dynamically and no need to add cases for different error responses. Also, adding this.xhr.onerror to handle errors with the xhr request.

Fixes #57 